### PR TITLE
[FIX] wrong paths in sourcemap

### DIFF
--- a/Classes/Parser/LessParser.php
+++ b/Classes/Parser/LessParser.php
@@ -93,6 +93,8 @@ class LessParser extends \KayStrobach\Dyncss\Parser\AbstractParser{
 
 			if($this->config['enableDebugMode']) {
 				$options['sourceMap'] = TRUE;
+				$options['sourceMapRootpath'] = '/';
+				$options['sourceMapBasepath'] = GeneralUtility::getIndpEnv('TYPO3_DOCUMENT_ROOT');
 			}
 
 			$files = array(


### PR DESCRIPTION
The sourcmap used a absolute path for the source-files (fixes #11)