### PR TITLE
[TASK] Set required TYPO3 version to lower 9.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "DynCss-Parser",
   "type": "typo3-cms-extension",
   "require": {
-    "typo3/cms-core": ">=7.6.15,<8.8",
+    "typo3/cms-core": ">=7.6.15,<9.5",
     "kaystrobach/dyncss": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Changed TYPO3 required version to lower 9.5 else composer cannot load the extension.