### PR TITLE
[TASK] Set required TYPO3 version to lower 10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "DynCss-Parser",
   "type": "typo3-cms-extension",
   "require": {
-    "typo3/cms-core": ">=7.6.15,<9.5",
+    "typo3/cms-core": ">=7.6.15,<10.0",
     "kaystrobach/dyncss": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Else cannot be found by composer in TYPO3 9.5.x