### PR TITLE
Revert "[BUGFIX] prevent some PHP warnings"

### DIFF
--- a/Resources/Private/Php/less.php/Exception/Chunk.php
+++ b/Resources/Private/Php/less.php/Exception/Chunk.php
@@ -67,7 +67,7 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 				case 40:
 					$parenLevel++;
 					$lastParen = $this->parserCurrentIndex;
-					break;
+					continue;
 
 				// )
 				case 41:
@@ -75,18 +75,18 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 					if( $parenLevel < 0 ){
 						return $this->fail("missing opening `(`");
 					}
-					break;
+					continue;
 
 				// ;
 				case 59:
 					//if (!$parenLevel) { $this->emitChunk();	}
-					break;
+					continue;
 
 				// {
 				case 123:
 					$level++;
 					$lastOpening = $this->parserCurrentIndex;
-					break;
+					continue;
 
 				// }
 				case 125:
@@ -96,7 +96,7 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 
 					}
 					//if (!$level && !$parenLevel) { $this->emitChunk(); }
-					break;
+					continue;
 				// \
 				case 92:
 					if ($this->parserCurrentIndex < $this->input_len - 1) { $this->parserCurrentIndex++; continue; }
@@ -145,14 +145,14 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 							return $this->fail("missing closing `*/`", $currentChunkStartIndex);
 						}
 					}
-					break;
+					continue;
 
 				// *, check for unmatched */
 				case 42:
 					if (($this->parserCurrentIndex < $this->input_len - 1) && ($this->CharCode($this->parserCurrentIndex+1) == 47)) {
 						return $this->fail("unmatched `/*`");
 					}
-					break;
+					continue;
 			}
 		}
 


### PR DESCRIPTION
This reverts commit c0bf07d4c8b41c4f8e212731e91f4d96fb8b9397.

Hi @kaystrobach  the last commit was uncomplete and unneccessary (i had another problem in compiling) (because it is uncomplete, and change is in "external lib", i would suggest to revert it.)