### PR TITLE
[BUGFIX] Avoid PHP 8.2 warning

### DIFF
--- a/Classes/Parser/LessParser.php
+++ b/Classes/Parser/LessParser.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class LessParser extends \KayStrobach\Dyncss\Parser\AbstractParser
 {
+    protected $parser;
 
     /**
      *


### PR DESCRIPTION
See https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties